### PR TITLE
Fill out functionality

### DIFF
--- a/nodes_test.go
+++ b/nodes_test.go
@@ -138,3 +138,20 @@ func TestNode_getNodes(t *testing.T) {
 	assert.Equal(t, "fooo1", *nodes[1].Id)
 	assert.Equal(t, "foo.zip", *nodes[1].Name)
 }
+
+func TestEscapeForFilter(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"potato", "potato"},
+		{`potato+sausage`, `potato\+sausage`},
+		{`+ - & | ! ( ) { } [ ] ^ ' " ~ * ? : \`, `\+\ \-\ \&\ \|\ \!\ \(\ \)\ \{\ \}\ \[\ \]\ \^\ \'\ \"\ \~\ \*\ \?\ \:\ \\`},
+	} {
+		got := EscapeForFilter(test.in)
+		if test.want != got {
+			t.Errorf("in(%q): want '%s' got '%s'", test.in, test.want, got)
+		}
+	}
+}


### PR DESCRIPTION
I've been using your library to add an Amazon Cloud Drive backend to rclone (see http://rclone.org )

I've managed to make the test suite pass with it.  In the process I've added quite a few things to your library.  I've tried not to break the external API in the process.

Here is the jumbo commit for you to look at.  With a bit of effort I could break this up into smaller commits if you want.

```
* AccountService methods
  * GetEndpoints - gets the users endpoints.
    * Updates the endpoints in the client when called
    * The library doesn't work in Europe unless you call this first
* Node methods
  * Add more fields to Node struct
  * Trash
  * Add NodeFromId for clients who wish to manage their own IDs
* File methods
  * Open - returns an io.ReadCloser to download a file
  * Make GetNode, GetFolder, GetFile return ErrorNotFound if appropriate
  * Overwrite - ovewrites an existing file from an io.Reader
* Folder methods
  * CreateFolder
  * Put - uploads a file from an io.Reader
  * FolderFromId for clients who wish to manage their own IDs
* Fixes
  * Fix error reporting so that it does return the Amazon error in the body
  * Fix escaping of names in query with EscapeForFilter
* Internal
  * Changed Client.Do so that it can return an unclosed resp.Body
```
